### PR TITLE
Support newer DMP0/zlib depth map format

### DIFF
--- a/descaniverse/__init__.py
+++ b/descaniverse/__init__.py
@@ -8,7 +8,26 @@ import os.path
 import shutil
 import numpy as np
 from scipy.spatial.transform import Rotation
+import zlib
 import liblzfse as lzfse
+
+
+def decode_depth_dmp(depth_buf):
+    """Decompress a Scaniverse ``.dmp`` depth file to raw float16 bytes.
+
+    Two on-disk formats are supported:
+
+    * Legacy: a bare LZFSE stream.
+    * Newer: a 12-byte header -- ``b'DMP0'`` magic, uint32 little-endian
+      file size, uint16 width, uint16 height -- followed by a
+      zlib-compressed float16 payload.
+
+    The format is detected from the leading magic bytes.
+    """
+    if depth_buf[:4] == b'DMP0':
+        return zlib.decompress(depth_buf[12:])
+    return lzfse.decompress(depth_buf)
+
 
 def message_to_dict(msg):
     return MessageToDict(msg, including_default_value_fields=True)
@@ -133,7 +152,7 @@ def scaniverse_to_nerfstudio(scaniverse_dir: Path, output_dir: Path,
             from PIL import Image
             input_depth_path = input_depth_dir/f"{file_base}.dmp"
             depth_buf = open(input_depth_path, 'br').read()
-            depth_buf = lzfse.decompress(depth_buf)
+            depth_buf = decode_depth_dmp(depth_buf)
             depth_data = np.frombuffer(depth_buf, dtype=np.float16)
             try:
                 depth_data = depth_data.reshape(h_depth, w_depth)


### PR DESCRIPTION
## Summary

`to_nerfstudio` fails with `liblzfse.error` on depth maps from newer
Scaniverse captures — depth `.dmp` files are no longer bare LZFSE streams.

Newer captures store depth as:

| offset | type    | meaning                         |
|--------|---------|---------------------------------|
| 0      | 4 bytes | `b'DMP0'` magic                 |
| 4      | uint32  | total file size (little-endian) |
| 8      | uint16  | width  (e.g. 256)               |
| 10     | uint16  | height (e.g. 192)               |
| 12     | ...     | zlib-compressed float16 payload |

The decompressed payload matches the legacy format: row-major float16
depth in meters, 0 = unknown.

## Changes

- Add `decode_depth_dmp()`, which detects the format from the leading
  magic bytes (zlib for `DMP0`, LZFSE otherwise).
- `to_nerfstudio` calls it instead of `lzfse.decompress` directly.

Legacy LZFSE scans are unaffected.

## Testing

Converted 9 scans (~6,800 frames) with `to_json` and `to_nerfstudio`;
depth PNGs decode to sane metric ranges.