### PR TITLE
Add to_pointcloud command and output options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ With older iOS versions the data can be accessed by creating a backup of the dev
 and extracting it using [ideviceunback](https://github.com/inflex/ideviceunback). The scans
 can be found in `/Library/Application Support/scans/` of the extracted backup. For newer iOS versions try [iOSbackup](https://pypi.org/project/iOSbackup/).
 
+A backup made with [iMazing](https://imazing.com/) works too: it is a standard (optionally encrypted) iOS backup, so the scans can be extracted from it with e.g. [iphone_backup_decrypt](https://github.com/jsharkey13/iphone_backup_decrypt) — no iMazing licence required.
+
 Alternatively, you can probably access these easily on jailbroken device. If you
 know a nicer way to access these files (without jailbreak), please leave an issue.
 
@@ -30,15 +32,24 @@ pip install git+https://github.com/jampekka/descaniverse
 A CLI interface is included as `descaniverse` runnable.
 
 ```console
-usage: descaniverse [-h] {to_json,to_nerfstudio} ...
+usage: descaniverse [-h] {to_json,to_nerfstudio,to_pointcloud} ...
 
 positional arguments:
-  {to_json,to_nerfstudio}
+  {to_json,to_nerfstudio,to_pointcloud}
     to_json             Converts Scaniverse metadata as-is to JSON
     to_nerfstudio       Converts a Scaniverse scan to nerfstudio format
+    to_pointcloud       Converts a Scaniverse scan to a colored point cloud
 
 optional arguments:
   -h, --help            show this help message and exit
 ```
+
+`to_json`, `to_nerfstudio` and `to_pointcloud` all accept `--append-scan-name` (append the scan's sanitized name to the output) and `--prefix-timestamp` (prefix the output name with the scan's capture time, formatted `YYYYMMDD-HHMMSS`).
+
+`to_pointcloud` additionally accepts `--z-up` (Z-up output, e.g. for CloudCompare) and `--georeference` (place the cloud in a real-world East-North-Up frame using the recorded GPS track). Its density is controlled by `--voxel-size` (downsampling cell size in meters) and `--max-frames`; `--voxel-size 0 --max-frames 0` keeps every point at full resolution.
+
+Recommended density: the Apple LiDAR depth maps are only 256×192, so the native point spacing is roughly 1 cm at typical scanning range. `--voxel-size 0.01 --max-frames 0` captures essentially all real detail and is the practical maximum; `--voxel-size 0.02` (the default) is a lighter general-purpose choice. Smaller voxel sizes — or `--voxel-size 0` — mostly add duplicate and noise-level points and can yield hundreds of millions of points on a longer scan.
+
+Giving the `to_pointcloud` output a `.las` extension instead of `.ply` writes a georeferenced LAS file in the local UTM zone (with the scan's capture date in the LAS header), ready to drop into QGIS, Cesium or other GIS tools. This needs the optional extras: `pip install descaniverse[las]`.
 
 ##

--- a/bin/descaniverse
+++ b/bin/descaniverse
@@ -6,5 +6,6 @@ from descaniverse import *
 defopt.run(dict(
         to_json=scaniverse_to_json,
         to_nerfstudio=scaniverse_to_nerfstudio,
+        to_pointcloud=scaniverse_to_pointcloud,
         ),
         cli_options='has_default')

--- a/descaniverse/__init__.py
+++ b/descaniverse/__init__.py
@@ -8,6 +8,8 @@ import os.path
 import shutil
 import numpy as np
 from scipy.spatial.transform import Rotation
+import re
+import unicodedata
 import zlib
 import liblzfse as lzfse
 
@@ -62,9 +64,45 @@ class FakePath:
         return self.file
 
 
-def scaniverse_to_json(scaniverse_dir: Path, output: Path=FakePath(sys.stdout, "STDOUT")):
+def _sanitize_name(name):
+    """Turn a scan name into a filesystem-safe ASCII slug."""
+    ascii_name = (
+        unicodedata.normalize("NFKD", name or "")
+        .encode("ascii", "ignore")
+        .decode("ascii")
+    )
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", ascii_name).strip("-")
+    return slug or "unnamed"
+
+
+def _with_scan_name(path, scan):
+    """Append a scan's sanitized name to a file or directory path."""
+    suffix = _sanitize_name(scan.name)
+    if path.suffix:
+        return path.with_name(f"{path.stem}_{suffix}{path.suffix}")
+    return path.with_name(f"{path.name}_{suffix}")
+
+
+def _with_timestamp_prefix(path, scan):
+    """Prefix a file or directory name with the scan's capture timestamp.
+
+    The timestamp is formatted YYYYMMDD-HHMMSS from the scan's createdAt.
+    """
+    import datetime
+    stamp = datetime.datetime.fromtimestamp(scan.createdAt).strftime(
+        "%Y%m%d-%H%M%S")
+    return path.with_name(f"{stamp}_{path.name}")
+
+
+def scaniverse_to_json(scaniverse_dir: Path, output: Path=FakePath(sys.stdout, "STDOUT"),
+                       append_scan_name: bool=False,
+                       prefix_timestamp: bool=False):
     """Converts Scaniverse metadata as-is to JSON"""
     scan = ScaniverseRawData(scaniverse_dir)
+    if append_scan_name and isinstance(output, Path):
+        output = _with_scan_name(output, scan.scan)
+    if prefix_timestamp and isinstance(output, Path):
+        output = _with_timestamp_prefix(output, scan.scan)
     if output is None:
         output = sys.stdout
     else:
@@ -74,10 +112,16 @@ def scaniverse_to_json(scaniverse_dir: Path, output: Path=FakePath(sys.stdout, "
 
 def scaniverse_to_nerfstudio(scaniverse_dir: Path, output_dir: Path,
                              depth_images: bool=True, copy_images: bool=True,
-                             max_frames: Optional[int]=None):
+                             max_frames: Optional[int]=None,
+                             append_scan_name: bool=False,
+                             prefix_timestamp: bool=False):
     """Converts a Scaniverse scan to nerfstudio format"""
     # TODO: Currently reads only large frames
     scan = ScaniverseRawData(scaniverse_dir)
+    if append_scan_name:
+        output_dir = _with_scan_name(output_dir, scan.scan)
+    if prefix_timestamp:
+        output_dir = _with_timestamp_prefix(output_dir, scan.scan)
     
     output_dir.mkdir(exist_ok=True)
     
@@ -179,7 +223,337 @@ def scaniverse_to_nerfstudio(scaniverse_dir: Path, output_dir: Path,
     from pprint import pprint
     #pprint(transforms, sort_dicts=False)
     #transforms = {
-    #    
+    #
     #        }
+
+
+def _voxel_downsample(points, colors, voxel_size):
+    """Keep one representative point (and its color) per voxel cell."""
+    cells = np.floor(points / voxel_size).astype(np.int64)
+    _, keep = np.unique(cells, axis=0, return_index=True)
+    return points[keep], colors[keep]
+
+
+def _write_ply(path, chunks):
+    """Stream (points, colors) chunks to a binary little-endian PLY file.
+
+    `chunks` is any iterable of (points Nx3, colors Nx3 uint8) arrays. The
+    vertex count is patched into the header once streaming is done, so the
+    whole cloud is never held in memory at once.
+    """
+    record = np.dtype([
+        ("x", "<f4"), ("y", "<f4"), ("z", "<f4"),
+        ("red", "u1"), ("green", "u1"), ("blue", "u1"),
+    ])
+    total = 0
+    with open(path, "wb") as fh:
+        fh.write(b"ply\nformat binary_little_endian 1.0\nelement vertex ")
+        count_offset = fh.tell()
+        fh.write(b" " * 24 + b"\n")  # placeholder, patched after streaming
+        fh.write(
+            b"property float x\nproperty float y\nproperty float z\n"
+            b"property uchar red\nproperty uchar green\nproperty uchar blue\n"
+            b"end_header\n"
+        )
+        for points, colors in chunks:
+            points = np.asarray(points)
+            colors = np.asarray(colors)
+            if len(points) == 0:
+                continue
+            vertex = np.empty(len(points), dtype=record)
+            vertex["x"], vertex["y"], vertex["z"] = points.T
+            vertex["red"], vertex["green"], vertex["blue"] = colors.T
+            fh.write(vertex.tobytes())
+            total += len(points)
+        fh.seek(count_offset)
+        fh.write(str(total).encode("ascii"))
+    return total
+
+
+def _utm_epsg(lat, lon):
+    """EPSG code of the WGS84 / UTM zone containing (lat, lon)."""
+    zone = int((lon + 180) / 6) % 60 + 1
+    return (32600 if lat >= 0 else 32700) + zone
+
+
+def _write_las(path, chunks, lat0, lon0, elev0, created=None):
+    """Write a georeferenced LAS file in the local UTM zone.
+
+    `chunks` yields (points, colors), where points are ENU meters about
+    (lat0, lon0, elev0). They are shifted into the UTM zone covering the
+    anchor and written with the matching CRS, so the file lands correctly
+    in QGIS, Cesium and other GIS tools. `created`, if given, is a Unix
+    timestamp written to the LAS header's creation-date field.
+    """
+    try:
+        import laspy
+        from pyproj import CRS, Transformer
+    except ImportError as e:
+        raise RuntimeError(
+            "LAS output needs extra packages: pip install laspy pyproj"
+        ) from e
+
+    epsg = _utm_epsg(lat0, lon0)
+    crs = CRS.from_epsg(epsg)
+    east0, north0 = Transformer.from_crs(
+        CRS.from_epsg(4326), crs, always_xy=True).transform(lon0, lat0)
+
+    points, colors = [], []
+    for chunk_points, chunk_colors in chunks:
+        if len(chunk_points):
+            points.append(np.asarray(chunk_points))
+            colors.append(np.asarray(chunk_colors))
+    if not points:
+        return 0
+    points = np.concatenate(points)
+    colors = np.concatenate(colors)
+
+    header = laspy.LasHeader(version="1.4", point_format=7)
+    header.add_crs(crs)
+    if created is not None:
+        import datetime
+        header.creation_date = datetime.date.fromtimestamp(created)
+    header.offsets = [east0, north0, elev0]
+    header.scales = [0.001, 0.001, 0.001]
+    las = laspy.LasData(header)
+    las.x = points[:, 0].astype(np.float64) + east0
+    las.y = points[:, 1].astype(np.float64) + north0
+    las.z = points[:, 2].astype(np.float64) + elev0
+    # LAS stores 16-bit color; 257 = 65535 / 255 maps 8-bit cleanly.
+    las.red = colors[:, 0].astype(np.uint16) * 257
+    las.green = colors[:, 1].astype(np.uint16) * 257
+    las.blue = colors[:, 2].astype(np.uint16) * 257
+    las.write(str(path))
+    return len(points)
+
+
+# Maps ARKit's Y-up coordinates to Z-up: out = points @ _YUP_TO_ZUP.T.
+_YUP_TO_ZUP = np.array([[1, 0, 0], [0, 0, -1], [0, 1, 0]], dtype=np.float64)
+
+
+def _gps_to_enu(locations, lat0, lon0, elev0):
+    """Convert GPS fixes to local East-North-Up meters about a reference.
+
+    Returns an (N, 4) array of (timestamp, east, north, up). Uses an
+    equirectangular approximation, accurate to well below GPS noise over
+    the small extent of a single scan.
+    """
+    earth_r = 6378137.0  # WGS84 equatorial radius, meters
+    lat0r, lon0r = np.radians(lat0), np.radians(lon0)
+    rows = []
+    for loc in locations:
+        east = earth_r * np.cos(lat0r) * (np.radians(loc.longitude) - lon0r)
+        north = earth_r * (np.radians(loc.latitude) - lat0r)
+        rows.append((loc.timestamp, east, north, loc.elevationMeters - elev0))
+    return np.array(rows, dtype=np.float64)
+
+
+def _georeference_transform(scan):
+    """Fit a transform mapping the scan into a local East-North-Up frame.
+
+    Uses the recorded GPS track: a horizontal rotation + translation
+    (Kabsch, scale fixed at 1 since both spaces are metric) and a vertical
+    offset are fitted between the camera trajectory and the GPS fixes,
+    sampled at matching timestamps.
+
+    Returns (M, t, info), where ``out = points @ M.T + t`` maps the native
+    Y-up cloud into the ENU frame and info carries reporting metadata.
+    """
+    fixes = list(scan.frames.locations)
+    if len(fixes) < 2:
+        raise RuntimeError("Scan has fewer than 2 GPS fixes; cannot georeference")
+
+    ref = scan.scan.location
+    lat0, lon0, elev0 = ref.latitude, ref.longitude, ref.elevationMeters
+    enu = _gps_to_enu(fixes, lat0, lon0, elev0)
+
+    frames = scan.frames.frames
+    cam_t = np.array([f.timestamp for f in frames], dtype=np.float64)
+    cam_p = np.array([list(f.transform.translation) for f in frames],
+                     dtype=np.float64) @ _YUP_TO_ZUP.T
+    order = np.argsort(cam_t)
+    cam_t, cam_p = cam_t[order], cam_p[order]
+
+    enu = enu[(enu[:, 0] >= cam_t[0]) & (enu[:, 0] <= cam_t[-1])]
+    if len(enu) < 2:
+        raise RuntimeError("GPS fixes do not overlap the frame timestamps")
+    local = np.stack([np.interp(enu[:, 0], cam_t, cam_p[:, i])
+                      for i in range(3)], axis=1)
+
+    src, dst = local[:, :2], enu[:, 1:3]
+    u, _, vt = np.linalg.svd((src - src.mean(0)).T @ (dst - dst.mean(0)))
+    flip = np.sign(np.linalg.det(vt.T @ u.T))
+    rot = vt.T @ np.diag([1.0, flip]) @ u.T
+    trans = dst.mean(0) - rot @ src.mean(0)
+    up_offset = enu[:, 3].mean() - local[:, 2].mean()
+    rms = float(np.sqrt(((src @ rot.T + trans - dst) ** 2).sum(1).mean()))
+
+    horizontal = np.eye(3)
+    horizontal[:2, :2] = rot
+    M = horizontal @ _YUP_TO_ZUP
+    t = np.array([trans[0], trans[1], up_offset])
+    info = dict(lat0=lat0, lon0=lon0, elev0=elev0, n_fixes=len(enu), rms=rms)
+    return M, t, info
+
+
+def _output_transform(scan, z_up, georeference):
+    """Return (M, t, info): out = points @ M.T + t for the chosen frame.
+
+    info is None unless georeferencing, in which case it carries the
+    anchor location and fit quality for reporting.
+    """
+    if georeference:
+        return _georeference_transform(scan)
+    if z_up:
+        return _YUP_TO_ZUP, np.zeros(3), None
+    return np.eye(3), np.zeros(3), None
+
+
+def scaniverse_to_pointcloud(scaniverse_dir: Path, output: Path,
+                             voxel_size: float = 0.02,
+                             max_frames: int = 2000,
+                             append_scan_name: bool = False,
+                             prefix_timestamp: bool = False,
+                             z_up: bool = False,
+                             georeference: bool = False):
+    """Converts a Scaniverse scan to a colored point cloud
+
+    Each depth map is back-projected to 3D using its per-frame camera
+    intrinsics and pose, colored from the matching small image and merged
+    into world space. The result is a binary PLY that opens directly in
+    CloudCompare, MeshLab or Blender.
+
+    :param scaniverse_dir: A Scaniverse scan directory (scan.pb, frames.pb,
+        depth/, img/).
+    :param output: Destination file. A .ply extension writes a binary PLY;
+        a .las extension writes a georeferenced LAS in the local UTM zone
+        (needs the optional laspy and pyproj packages; implies
+        georeferencing).
+    :param voxel_size: Voxel-downsampling cell size in meters; smaller is
+        denser. Use 0 to keep every point (no downsampling).
+    :param max_frames: Approximate number of frames to use, sampled at a
+        uniform stride across the scan. Use 0 to use every frame.
+    :param append_scan_name: Append the scan's sanitized name to the output
+        filename (e.g. cloud.ply -> cloud_My-Scan.ply).
+    :param prefix_timestamp: Prefix the output filename with the scan's
+        capture timestamp, formatted YYYYMMDD-HHMMSS.
+    :param z_up: Rotate the output from Scaniverse's native Y-up frame
+        (ARKit is gravity-aligned with Y up) to a Z-up frame, as expected
+        by CloudCompare and Blender.
+    :param georeference: Place the cloud in a local East-North-Up frame
+        anchored at the scan's GPS location, fitted from the recorded GPS
+        track. Implies Z-up. Accuracy is limited by consumer GPS (the
+        horizontal fit RMS, a few meters, is printed).
+    """
+    from PIL import Image
+
+    scan = ScaniverseRawData(scaniverse_dir)
+    if append_scan_name:
+        output = _with_scan_name(output, scan.scan)
+    if prefix_timestamp:
+        output = _with_timestamp_prefix(output, scan.scan)
+    frames = list(scan.frames.frames)
+    stride = max(1, len(frames) // max_frames) if max_frames else 1
+    sampled = frames[::stride]
+
+    want_las = output.suffix.lower() == ".las"
+    if want_las and not georeference:
+        georeference = True
+        print("LAS output: enabling georeferencing (LAS needs a CRS)")
+    transform, offset, geo = _output_transform(scan, z_up, georeference)
+    transform = transform.astype(np.float32)
+    offset = offset.astype(np.float32)
+
+    def frame_chunks():
+        """Yield (points, colors) for each used frame, in output coords."""
+        total = len(sampled)
+        for i, frame in enumerate(sampled):
+            if i % 50 == 0:
+                print(f"\r  frame {i}/{total} ({100 * i / total:.0f}%)",
+                      end="", file=sys.stderr, flush=True)
+            base = f"{frame.id:>05d}"
+            depth_path = scaniverse_dir / "depth" / f"{base}.dmp"
+            image_path = scaniverse_dir / "img" / f"{base}.jpg"
+            if not depth_path.exists() or not image_path.exists():
+                continue
+
+            camera = frame.camera
+            w, h = int(camera.width), int(camera.height)
+            depth = np.frombuffer(
+                decode_depth_dmp(depth_path.read_bytes()), dtype=np.float16,
+            ).astype(np.float32)
+            if depth.size != w * h:
+                print(f"Skipping frame {frame.id}; unexpected depth size",
+                      file=sys.stderr)
+                continue
+            depth = depth.reshape(h, w)
+
+            image = Image.open(image_path).convert("RGB")
+            if image.size != (w, h):
+                image = image.resize((w, h))
+            image = np.asarray(image)
+
+            near = max(float(frame.depth_range.near), 1e-3)
+            far = float(frame.depth_range.far)
+            us, vs = np.meshgrid(np.arange(w), np.arange(h))
+            valid = (depth > near) & (depth < far) & np.isfinite(depth)
+            if not valid.any():
+                continue
+            d = depth[valid]
+            u = us[valid].astype(np.float32)
+            v = vs[valid].astype(np.float32)
+
+            # Scaniverse uses the COLMAP camera convention (x right, y down,
+            # z forward) and stores camera-to-world poses directly.
+            cam_xyz = np.stack([
+                (u - camera.px) / camera.f * d,
+                (v - camera.py) / camera.f * d,
+                d,
+            ], axis=1)
+            rotation = Rotation.from_quat(
+                np.asarray(frame.transform.rotation)).as_matrix()
+            translation = np.asarray(frame.transform.translation,
+                                     dtype=np.float32)
+            world = (cam_xyz @ rotation.T + translation).astype(np.float32)
+            world = world @ transform.T + offset
+            yield world, image[vs[valid], us[valid]]
+        print(f"\r  frame {total}/{total} (100%)", file=sys.stderr)
+
+    def write(chunks):
+        if want_las:
+            return _write_las(output, chunks, geo["lat0"], geo["lon0"],
+                              geo["elev0"], scan.scan.createdAt)
+        return _write_ply(output, chunks)
+
+    if voxel_size and voxel_size > 0:
+        kept_pts, kept_cols, n = [], [], 0
+        for points, colors in frame_chunks():
+            kept_pts.append(points)
+            kept_cols.append(colors)
+            n += 1
+            if n % 100 == 0:
+                points, colors = _voxel_downsample(
+                    np.concatenate(kept_pts), np.concatenate(kept_cols),
+                    voxel_size)
+                kept_pts, kept_cols = [points], [colors]
+        if not kept_pts:
+            raise RuntimeError(f"No usable frames found in {scaniverse_dir}")
+        points, colors = _voxel_downsample(
+            np.concatenate(kept_pts), np.concatenate(kept_cols), voxel_size)
+        total = write([(points, colors)])
+    else:
+        total = write(frame_chunks())
+    if total == 0:
+        raise RuntimeError(f"No usable frames found in {scaniverse_dir}")
+
+    if geo:
+        print(f"Georeferenced to ENU about lat={geo['lat0']:.7f}, "
+              f"lon={geo['lon0']:.7f}, elev={geo['elev0']:.2f} m -- "
+              f"{geo['n_fixes']} GPS fixes, horizontal fit RMS "
+              f"{geo['rms']:.2f} m")
+    if want_las:
+        print(f"LAS coordinates: UTM, EPSG:"
+              f"{_utm_epsg(geo['lat0'], geo['lon0'])}")
+    print(f"Wrote {total:,} points to {output}")
 
  

--- a/descaniverse/__init__.py
+++ b/descaniverse/__init__.py
@@ -8,7 +8,26 @@ import os.path
 import shutil
 import numpy as np
 from scipy.spatial.transform import Rotation
+import zlib
 import liblzfse as lzfse
+
+
+def decode_depth_dmp(depth_buf):
+    """Decompress a Scaniverse ``.dmp`` depth file to raw float16 bytes.
+
+    Two on-disk formats are supported:
+
+    * Legacy: a bare LZFSE stream.
+    * Newer: a 12-byte header -- ``b'DMP0'`` magic, uint32 little-endian
+      file size, uint16 width, uint16 height -- followed by a
+      zlib-compressed float16 payload.
+
+    The format is detected from the leading magic bytes.
+    """
+    if depth_buf[:4] == b'DMP0':
+        return zlib.decompress(depth_buf[12:])
+    return lzfse.decompress(depth_buf)
+
 
 def message_to_dict(msg):
     return MessageToDict(msg, including_default_value_fields=True)
@@ -133,7 +152,7 @@ def scaniverse_to_nerfstudio(scaniverse_dir: Path, output_dir: Path,
             from PIL import Image
             input_depth_path = input_depth_dir/f"{file_base}.dmp"
             depth_buf = open(input_depth_path, 'br').read()
-            depth_buf = lzfse.decompress(depth_buf)
+            depth_buf = decode_depth_dmp(depth_buf)
             depth_data = np.frombuffer(depth_buf, dtype=np.float16)
             try:
                 depth_data = depth_data.reshape(h_depth, w_depth)

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,9 @@ setup(name='descaniverse',
         'defopt',
         'Pillow',
       ],
+      # Optional: only needed for `to_pointcloud` LAS output.
+      extras_require={
+        'las': ['laspy', 'pyproj'],
+      },
       zip_safe=False)
 


### PR DESCRIPTION
## Summary

A new subcommand and a set of output options for `to_pointcloud`.

**`to_pointcloud`** — fuses a scan's RGB-D frames into a colored point
cloud. Each depth map is back-projected to 3D with its per-frame camera
intrinsics and pose, colored from the matching small image and merged
into world space. Output is a binary PLY (written as a stream, so a
full-resolution cloud is never held in memory) or a georeferenced LAS.

**Options**

- `--append-scan-name` / `--prefix-timestamp` (on `to_json`,
  `to_nerfstudio`, `to_pointcloud`) -- add the scan's name and/or capture
  timestamp (`YYYYMMDD-HHMMSS`) to the output name.
- `--z-up` -- rotate from ARKit's native Y-up frame to Z-up.
- `--georeference` -- place the cloud in a local East-North-Up frame,
  fitted from the recorded GPS track.
- `--voxel-size` / `--max-frames` -- density control; `0` disables
  downsampling / frame subsampling.

**LAS output** -- a `.las` output extension writes a georeferenced LAS in
the local UTM zone, with the CRS and the scan's capture date embedded.
Needs the optional `[las]` extra (`laspy`, `pyproj`).

## Notes

- Built on top of #2 (DMP0/zlib depth fix); `to_pointcloud` reuses
  `decode_depth_dmp()`. That commit is included here, so the diff will
  shrink once #2 merges.
- LAS is the only feature that adds dependencies, and they are optional.

## Testing

All three subcommands run with the new flags; PLY and LAS outputs verified.
LAS opens correctly placed in QGIS (EPSG:32629); georeferencing checked
against satellite imagery -- the footprint lands accurately.